### PR TITLE
Improve build script to also ZIP binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,18 @@ TVD_VERSION=`git describe --tags`
 rm -rf dist/*
 
 # build the binaries
-GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X main.ClientID=${TWITCH_CLIENT_ID} main.Version=${VERSION}" -o dist/darwin-amd64/tvd
-GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.ClientID=${TWITCH_CLIENT_ID} main.Version=${VERSION}" -o dist/linux-amd64/tvd
-GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X main.ClientID=${TWITCH_CLIENT_ID} main.Version=${VERSION}" -o dist/windows-amd64/tvd.exe
+GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X main.ClientID=${TWITCH_CLIENT_ID} -X main.Version=${TVD_VERSION}" -o dist/darwin-amd64/tvd
+GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.ClientID=${TWITCH_CLIENT_ID} -X main.Version=${TVD_VERSION}" -o dist/linux-amd64/tvd
+GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X main.ClientID=${TWITCH_CLIENT_ID} -X main.Version=${TVD_VERSION}" -o dist/windows-amd64/tvd.exe
+
+# package the binaries
+cd dist
+for dir in ./*/; do
+    cleanDir="${dir%/}"
+    cleanDir="${cleanDir##*/}"
+    cd $dir
+    for file in "./"*; do
+        zip -r "../$cleanDir.zip" $file
+    done
+    cd ..
+done


### PR DESCRIPTION
The build script will now ZIP each binary with the same folder name it's found under. Also, fixes an error with the version env variable name.