### PR TITLE
Log config with censored ClientID

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -25,6 +25,13 @@ type Config struct {
 	Workers      int
 }
 
+// WithoutClientID returns a copy of the struct with the ClientID field censored (e.g. for logging)
+func (c Config) WithoutClientID() Config {
+	c2 := c
+	c2.ClientID = "********"
+	return c2
+}
+
 // Update replaces any config values in the base object with those present in the passed argument
 func (c *Config) Update(c2 Config) {
 	if c2.ClientID != "" {

--- a/tvd.go
+++ b/tvd.go
@@ -64,7 +64,7 @@ func main() {
 		fmt.Println(err)
 		log.Fatalln(err)
 	}
-	log.Printf("Final config: %+v\n", config)
+	log.Printf("Final config: %+v\n", config.WithoutClientID())
 	err = config.Validate()
 	if err != nil {
 		fmt.Println(err)
@@ -423,7 +423,7 @@ func loadConfig(f string) Config {
 		Quality:  "best",
 		Workers:  4,
 	}
-	log.Printf("Default config: %+v\n", config)
+	log.Printf("Default config: %+v\n", config.WithoutClientID())
 
 	configData, err := ioutil.ReadFile(f)
 	if err != nil {
@@ -437,7 +437,7 @@ func loadConfig(f string) Config {
 		return config
 	}
 
-	log.Printf("Config after parsing config file: %+v\n", config)
+	log.Printf("Config after parsing config file: %+v\n", config.WithoutClientID())
 	return config
 }
 
@@ -493,7 +493,7 @@ func parseFlags() (Config, error) {
 		config.VodID = vID
 	}
 
-	log.Printf("Flag config: %+v\n", config)
+	log.Printf("Flag config: %+v\n", config.WithoutClientID())
 	return config, nil
 }
 


### PR DESCRIPTION
Add a method to `Config` which returns a copy with the ClientID field censored. Update logging calls which record the current config to use the censored version.