### PR TITLE
Disable draft mode in build pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,12 +21,6 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-next"
-changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^test:'
 build:
   binary: tvd
   ldflags: "-s -w -X main.Version={{ .Version }} -X main.ClientID={{ .Env.TVD_CLIENT_ID }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ brew:
   name: tvd
   github:
     owner: dbarbuzzi
-    name: hombrew-tap
+    name: homebrew-tap
   commit_author:
     name: dbarbuzzi
     email: dbarbuzzi@gmail.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,6 @@ release:
   github:
     owner: dbarbuzzi
     name: tvd
-  draft: true
 archive:
   replacements:
     darwin: macOS


### PR DESCRIPTION
Fixes a couple issues with the goreleaser config and disables the draft mode

* Primarily because it doesn't appear to generate a Scoop manifest in the dist folder like it does a Homebrew formula
* Secondarily because it will be nicer to let the automated release also update the Homebrew / Scoop things automatically