### PR TITLE
Update CircleCI config to use Pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,22 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11
-    working_directory: /go/src/github.com/dbarbuzzi/tvd
+      # specify the version
+      - image: circleci/golang:1.15
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout
+
+      # specify any bash command here prefixed with `run: `
       - run: go get -v -t -d ./...
       - run: go test -v ./...


### PR DESCRIPTION
Update the CircleCI config to use Pipelines via their default config file.