### PR TITLE
Hotfix: Improve logic for validating Client ID env var

### DIFF
--- a/clientid_check.sh
+++ b/clientid_check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ ${#TVD_CLIENT_ID} -ne 30 ]
+if [ ${#TVD_CLIENT_ID} -lt 30 ]
 then
   exit 1
 fi


### PR DESCRIPTION
Newer Client-ID from a Twitch app was 31 chars which broke the validation – improve logic to expect the Client-ID env var to be at least 30 chars (may need tweaking in the future).