### PR TITLE
Update stdout related to cleaning up temp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ tvd (**T**witch **V**OD **D**ownloader) is a command-line tool to download VODs 
 
 * If building from source, you must have a client ID with appropriate privileges to query the GQL API for VODs
   * Provided releases have an embedded client ID
-* You must have an active auth token from an account sign-in
-  * In a browser, sign into your account and get the value of the `auth-token` cookie
 
 ## Download
 
@@ -43,7 +41,6 @@ Using a config file is alternative to command-line arguments. It can be used in 
 
 The accepted values are:
 
-* `AuthToken` - your login session’s auth token (stored in `auth-token` cookies)
 * `ClientID` - your Twitch app’s client ID
 * `Quality` (optional) - desired quality (e.g. “720p60”, “480p30”); can use “best” for best available (default: "best")
 * `StartTime` – start time in the format "HOURS MINUTES SECONDS" (e.g. "1 24 35" is 1h24m35s)
@@ -59,7 +56,6 @@ The accepted values are:
 
 All options supported above are also supported through the command-line under the following flags:
 
-* `auth` => `AuthToken`
 * `client` => `ClientID`
 * `quality` => `Quality`
 * `start` => `StartTime`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tvd (**T**witch **V**OD **D**ownloader) is a command-line tool to download VODs 
 
 ## Prerequisites
 
-* If building from source, you must register a new app on the Twitch Dev site to get your own client ID
+* If building from source, you must have a client ID with appropriate privileges to query the GQL API for VODs
   * Provided releases have an embedded client ID
 * You must have an active auth token from an account sign-in
   * In a browser, sign into your account and get the value of the `auth-token` cookie

--- a/config-sample.toml
+++ b/config-sample.toml
@@ -1,4 +1,3 @@
-AuthToken = "<access token from browser cookies>"
 ClientID="<twitch api client id>"
 Quality="best"
 StartTime="0 0 0"

--- a/config.go
+++ b/config.go
@@ -12,7 +12,6 @@ import (
 
 // Config represents a config object containing everything needed to download a VOD
 type Config struct {
-	AuthToken    string
 	ClientID     string
 	Quality      string
 	StartTime    string
@@ -29,16 +28,12 @@ type Config struct {
 // Privatize returns a copy of the struct with the ClientID field censored (e.g. for logging)
 func (c Config) Privatize() Config {
 	c2 := c
-	c2.AuthToken = "********"
 	c2.ClientID = "********"
 	return c2
 }
 
 // Update replaces any config values in the base object with those present in the passed argument
 func (c *Config) Update(c2 Config) {
-	if c2.AuthToken != "" {
-		c.AuthToken = c2.AuthToken
-	}
 	if c2.ClientID != "" {
 		c.ClientID = c2.ClientID
 	}
@@ -73,9 +68,6 @@ func (c *Config) Update(c2 Config) {
 //
 // Currently, "OutputFolder" is not validated (needs logic to support Windows paths)
 func (c Config) Validate() error {
-	if len(c.AuthToken) == 0 {
-		return fmt.Errorf("error: AuthToken missing")
-	}
 	if len(c.ClientID) == 0 {
 		return fmt.Errorf("error: ClientID missing")
 	}
@@ -171,9 +163,6 @@ func loadConfig(f string) (Config, error) {
 func buildConfigFromFlags() (Config, error) {
 	var config Config
 
-	if *authToken != "" {
-		config.AuthToken = *authToken
-	}
 	if *clientID != "" {
 		config.ClientID = *clientID
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.0
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/osrtss/rtss v0.0.0-20170322072109-b1617c76f6da
+	github.com/grafov/m3u8 v0.11.1
 	github.com/pkg/errors v0.8.0
 	github.com/schollz/progressbar/v3 v3.7.3
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.0
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/osrtss/rtss v0.0.0-20170322072109-b1617c76f6da
 	github.com/pkg/errors v0.8.0
 	github.com/schollz/progressbar/v3 v3.7.3
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/grafov/m3u8 v0.11.1 h1:igZ7EBIB2IAsPPazKwRKdbhxcoBKO3lO1UY57PZDeNA=
+github.com/grafov/m3u8 v0.11.1/go.mod h1:nqzOkfBiZJENr52zTVd/Dcl03yzphIMbJqkXGu+u080=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -15,8 +17,6 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-github.com/osrtss/rtss v0.0.0-20170322072109-b1617c76f6da h1:/Z/TuENqR/F8BVs0WUpAIegWgfKY8EoP93i3kRMapRQ=
-github.com/osrtss/rtss v0.0.0-20170322072109-b1617c76f6da/go.mod h1:HP7OZkbc9jh3kEc5zfljE3gG++ejTIbq3HZRui5n+mo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/osrtss/rtss v0.0.0-20170322072109-b1617c76f6da h1:/Z/TuENqR/F8BVs0WUpAIegWgfKY8EoP93i3kRMapRQ=
+github.com/osrtss/rtss v0.0.0-20170322072109-b1617c76f6da/go.mod h1:HP7OZkbc9jh3kEc5zfljE3gG++ejTIbq3HZRui5n+mo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/structs.go
+++ b/structs.go
@@ -45,12 +45,6 @@ func isValidFilename(fn string) bool {
 	return true
 }
 
-// AuthTokenResponse represents the (happy) JSON response to a token request call
-type AuthTokenResponse struct {
-	Sig   string `json:"sig"`
-	Token string `json:"token"`
-}
-
 // Chunk represents a video chunk from the m3u
 type Chunk struct {
 	Name   string

--- a/structs.go
+++ b/structs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 	"net/url"
 	"path/filepath"
@@ -56,4 +57,41 @@ type Chunk struct {
 	Length float64
 	URL    *url.URL
 	Path   string
+}
+
+// AuthGQLPayload represents the payload sent to the GQL endpoint to get the
+// auth token and signature
+type AuthGQLPayload struct {
+	OperationName string `json:"operationName"`
+	Query         string `json:"query"`
+	Variables     struct {
+		IsLive     bool   `json:"isLive"`
+		IsVod      bool   `json:"isVod"`
+		Login      string `json:"login"`
+		PlayerType string `json:"playerType"`
+		VodID      string `json:"vodID"`
+	} `json:"variables"`
+}
+
+func generateAuthPayload(vodID string) ([]byte, error) {
+	ap := AuthGQLPayload{
+		OperationName: "PlaybackAccessToken_Template",
+		Query:         "query PlaybackAccessToken_Template($login: String!, $isLive: Boolean!, $vodID: ID!, $isVod: Boolean!, $playerType: String!) {  streamPlaybackAccessToken(channelName: $login, params: {platform: \"web\", playerBackend: \"mediaplayer\", playerType: $playerType}) @include(if: $isLive) {    value    signature    __typename  }  videoPlaybackAccessToken(id: $vodID, params: {platform: \"web\", playerBackend: \"mediaplayer\", playerType: $playerType}) @include(if: $isVod) {    value    signature    __typename  }}",
+	}
+	ap.Variables.IsLive = false
+	ap.Variables.IsVod = true
+	ap.Variables.PlayerType = "site"
+	ap.Variables.VodID = vodID
+	return json.Marshal(ap)
+}
+
+// AuthGQLPayload represents the response from to the GQL endpoint containing
+// the auth token and signature
+type AuthGQLResponse struct {
+	Data struct {
+		VideoPlaybackAccessToken struct {
+			Value     string `json:"value"`
+			Signature string `json:"signature"`
+		} `json:"videoPlaybackAccessToken"`
+	} `json:"data"`
 }

--- a/tvd.go
+++ b/tvd.go
@@ -574,25 +574,3 @@ func secondsToTimeMask(s int) string {
 	log.Printf("masked %d seconds as '%s'\n", s, res)
 	return res
 }
-
-func readURL(url string) ([]byte, error) {
-	log.Printf("requesting URL: %s\n", url)
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			fmt.Printf("error closing URL body for <%s>: %s", url, err.Error())
-			log.Println(err)
-		}
-	}()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
-}

--- a/tvd.go
+++ b/tvd.go
@@ -268,7 +268,7 @@ func getAccessData(vodID int, clientID string) (AuthGQLResponse, error) {
 	}
 	if len(ar.Data.VideoPlaybackAccessToken.Signature) == 0 || len(ar.Data.VideoPlaybackAccessToken.Value) == 0 {
 		log.Printf("response: %s\n", rspData)
-		return ar, fmt.Errorf("error: sig and/or token were empty: %+v", ar)
+		return ar, fmt.Errorf("error: sig and/or token were empty; response body: %+v", ar)
 	}
 
 	log.Printf("access token: %+v\n", ar)
@@ -300,6 +300,7 @@ func getStreamOptions(vodID int, ar AuthGQLResponse) (map[string]string, error) 
 
 	p, listType, err := m3u8.DecodeFrom(rsp.Body, true)
 	if err != nil {
+		log.Printf("failed to decode m3u8: %s\n", err.Error())
 		return nil, err
 	}
 
@@ -316,6 +317,7 @@ func getStreamOptions(vodID int, ar AuthGQLResponse) (map[string]string, error) 
 
 		}
 	default:
+		log.Println("m3u8 playlist was not the expected 'master' format")
 		return nil, fmt.Errorf("m3u8 playlist was not the expected 'master' format")
 	}
 
@@ -342,6 +344,7 @@ func getChunks(streamURL string) ([]Chunk, int, error) {
 
 	p, listType, err := m3u8.DecodeFrom(rsp.Body, true)
 	if err != nil {
+		log.Printf("failed to decode m3u8: %s\n", err.Error())
 		return nil, 0, err
 	}
 
@@ -362,6 +365,7 @@ func getChunks(streamURL string) ([]Chunk, int, error) {
 			chunks = append(chunks, Chunk{Name: s.URI, Length: s.Duration, URL: chunkURL})
 		}
 	default:
+		log.Println("m3u8 playlist was not the expected 'media' format")
 		return nil, 0, fmt.Errorf("m3u8 playlist was not the expected 'media' format")
 	}
 

--- a/tvd.go
+++ b/tvd.go
@@ -135,6 +135,7 @@ func main() {
 		fmt.Println(err)
 		log.Fatalln(err)
 	}
+	log.Printf("final config: %+v\n", config.Privatize())
 
 	// go get it!
 	err = DownloadVOD(config)

--- a/tvd.go
+++ b/tvd.go
@@ -165,7 +165,7 @@ func createDefaultConfigFile() error {
 // DownloadVOD downloads a VOD based on the various info passed in the config
 func DownloadVOD(cfg Config) error {
 	fmt.Println("Fetching access token")
-	ar, err := getAuthToken(cfg.VodID, cfg.ClientID)
+	ar, err := getAccessData(cfg.VodID, cfg.ClientID)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func DownloadVOD(cfg Config) error {
 	return nil
 }
 
-func getAuthToken(vodID int, clientID string) (AuthGQLResponse, error) {
+func getAccessData(vodID int, clientID string) (AuthGQLResponse, error) {
 	log.Printf("[getAuthToken] vodID=%d\n", vodID)
 	var ar AuthGQLResponse
 

--- a/tvd.go
+++ b/tvd.go
@@ -32,7 +32,6 @@ var (
 	date    = "n/a"
 
 	DefaultConfig = Config{
-		AuthToken: "",
 		ClientID:  ClientID,
 		Workers:   4,
 		StartTime: "0 0 0",
@@ -46,7 +45,6 @@ var (
 
 // command-line args/flags
 var (
-	authToken  = kingpin.Flag("auth", "Account session access token from browser sign-in session").Short('T').String()
 	clientID   = kingpin.Flag("client", "Twitch app Client ID").Short('C').String()
 	workers    = kingpin.Flag("workers", "Max number of concurrent downloads (default: 4)").Short('w').Int()
 	configFile = kingpin.Flag("config", "Path to config file (default: $HOME/.config/tvd/config.toml)").Short('c').String()

--- a/tvd.go
+++ b/tvd.go
@@ -205,9 +205,10 @@ func DownloadVOD(cfg Config) error {
 		return err
 	}
 	defer func() {
+		fmt.Println("Cleaning up temp files")
 		err = os.RemoveAll(tempDir)
 		if err != nil {
-			fmt.Printf("Failed to remove dir <%s>\n", tempDir)
+			fmt.Printf("Failed to remove tempdir <%s>\n", tempDir)
 			log.Fatalln(err)
 		}
 	}()

--- a/tvd.go
+++ b/tvd.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/osrtss/rtss/m3u8"
+	"github.com/grafov/m3u8"
 	"github.com/schollz/progressbar/v3"
 	"gopkg.in/alecthomas/kingpin.v2"
 )


### PR DESCRIPTION
It seems that the deprecated/protected endpoint previously used to get access data for the VOD M3U playlist files is no longer functional. The main changes in this PR resolve that issue.

Of note:
* Access data endpoint is swapped to use the new GQL endpoint with a relevant query
  * Positive side effect: OAuth auth token is no longer required and has been excised from the project
  * Negative side effect: Client-ID requires privileges not afforded by dev API, using code directly rather than published releases will be more difficult
* M3U master playlist endpoint is swapped to a newer(?) endpoint
* M3U handling has been switched to github.com/grafov/m3u8 rather than continuing to maintain homegrown regex
* Log file contents are updated with relevant changes/additions/removals